### PR TITLE
Add three comic-style octopus logo variants

### DIFF
--- a/frontend/src/assets/logo/octopus-comic-v1.svg
+++ b/frontend/src/assets/logo/octopus-comic-v1.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" fill="none">
+  <!-- Version 1: Bold Comic Style - Heavy outlines, halftone shading -->
+  <title>BOSSVIEW Octopus - Bold Comic Style</title>
+
+  <!-- Head -->
+  <path d="M250 80 C310 80 360 120 370 180 C380 240 350 280 320 300 C300 312 280 316 250 316 C220 316 200 312 180 300 C150 280 120 240 130 180 C140 120 190 80 250 80Z"
+        fill="white" stroke="black" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Head shading - halftone dots pattern -->
+  <defs>
+    <pattern id="halftone1" x="0" y="0" width="8" height="8" patternUnits="userSpaceOnUse">
+      <circle cx="4" cy="4" r="1.5" fill="black"/>
+    </pattern>
+    <pattern id="halftone-dense1" x="0" y="0" width="6" height="6" patternUnits="userSpaceOnUse">
+      <circle cx="3" cy="3" r="2" fill="black"/>
+    </pattern>
+    <clipPath id="head-clip1">
+      <path d="M250 80 C310 80 360 120 370 180 C380 240 350 280 320 300 C300 312 280 316 250 316 C220 316 200 312 180 300 C150 280 120 240 130 180 C140 120 190 80 250 80Z"/>
+    </clipPath>
+  </defs>
+
+  <!-- Head shadow area -->
+  <path d="M300 100 C350 130 370 180 370 200 C360 260 340 290 320 300 C300 312 280 316 260 316 C280 290 310 240 310 180 C310 140 300 110 300 100Z"
+        fill="url(#halftone1)" clip-path="url(#head-clip1)"/>
+
+  <!-- Head highlight line -->
+  <path d="M220 110 C230 100 245 95 250 100" stroke="black" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M210 125 C215 118 220 115 222 117" stroke="black" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- Eye - large expressive comic eye -->
+  <ellipse cx="260" cy="200" rx="40" ry="45" fill="white" stroke="black" stroke-width="5"/>
+  <!-- Iris -->
+  <circle cx="265" cy="205" r="22" fill="black"/>
+  <!-- Pupil highlight -->
+  <circle cx="272" cy="193" r="8" fill="white"/>
+  <circle cx="260" cy="210" r="4" fill="white"/>
+  <!-- Eye detail lines -->
+  <path d="M222 185 C225 178 235 172 245 170" stroke="black" stroke-width="3" fill="none" stroke-linecap="round"/>
+
+  <!-- Second eye (partially hidden) -->
+  <ellipse cx="195" cy="210" rx="22" ry="26" fill="white" stroke="black" stroke-width="4"/>
+  <circle cx="192" cy="213" r="13" fill="black"/>
+  <circle cx="197" cy="206" r="5" fill="white"/>
+
+  <!-- Brow line -->
+  <path d="M215 170 C230 160 270 155 305 168" stroke="black" stroke-width="4" fill="none" stroke-linecap="round"/>
+
+  <!-- Tentacle 1 - front left, curling down -->
+  <path d="M200 300 C180 340 140 380 120 420 C108 445 115 460 130 455 C145 450 148 435 145 420 C142 400 155 370 170 350"
+        fill="white" stroke="black" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Suckers -->
+  <circle cx="175" cy="330" r="5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="160" cy="355" r="5.5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="145" cy="380" r="5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="132" cy="405" r="4.5" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="128" cy="430" r="4" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Tentacle 2 - front right, sweeping right -->
+  <path d="M300 300 C330 340 370 370 410 380 C440 387 458 375 450 358 C442 341 420 342 400 350 C375 360 350 345 330 325"
+        fill="white" stroke="black" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Suckers -->
+  <circle cx="325" cy="330" r="5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="350" cy="350" r="5.5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="378" cy="365" r="5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="405" cy="372" r="4.5" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="430" cy="370" r="4" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Tentacle 3 - back left, going up and curling -->
+  <path d="M160 280 C130 260 90 250 60 270 C40 282 42 300 58 305 C74 310 85 298 90 280 C95 262 115 258 140 268"
+        fill="white" stroke="black" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="130" cy="268" r="4.5" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="108" cy="260" r="4.5" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="85" cy="262" r="4" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="68" cy="278" r="3.5" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Tentacle 4 - back right, going up -->
+  <path d="M340 280 C370 255 410 240 440 250 C460 257 465 275 450 285 C435 295 420 285 415 268 C410 251 388 248 360 262"
+        fill="white" stroke="black" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="370" cy="263" r="4.5" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="395" cy="253" r="4.5" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="418" cy="255" r="4" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="438" cy="265" r="3.5" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Tentacle 5 - lower left -->
+  <path d="M220 315 C200 360 170 420 160 460 C155 478 165 488 178 482 C191 476 190 460 185 440 C178 410 195 380 215 345"
+        fill="white" stroke="black" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="205" cy="345" r="5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="192" cy="375" r="5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="180" cy="405" r="4.5" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="172" cy="435" r="4" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Tentacle 6 - lower right -->
+  <path d="M280 315 C300 360 330 420 345 455 C352 472 345 485 330 480 C315 475 318 458 325 438 C335 408 315 375 295 345"
+        fill="white" stroke="black" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="295" cy="345" r="5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="310" cy="378" r="5" fill="none" stroke="black" stroke-width="2.5"/>
+  <circle cx="325" cy="408" r="4.5" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="338" cy="440" r="4" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Tentacle 7 - far left down -->
+  <path d="M170 295 C140 320 100 360 75 400 C60 425 68 445 85 440 C102 435 100 415 95 395 C88 370 108 340 135 315"
+        fill="white" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="125" cy="330" r="4" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="105" cy="358" r="4" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="88" cy="385" r="3.5" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Tentacle 8 - far right down -->
+  <path d="M330 295 C360 320 400 355 425 390 C440 413 433 435 416 432 C399 429 400 410 405 390 C412 365 393 338 365 315"
+        fill="white" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="375" cy="328" r="4" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="398" cy="355" r="4" fill="none" stroke="black" stroke-width="2"/>
+  <circle cx="415" cy="385" r="3.5" fill="none" stroke="black" stroke-width="2"/>
+
+  <!-- Speed/action lines (comic effect) -->
+  <line x1="50" y1="150" x2="30" y2="145" stroke="black" stroke-width="2" stroke-linecap="round"/>
+  <line x1="55" y1="170" x2="25" y2="172" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="52" y1="190" x2="32" y2="195" stroke="black" stroke-width="2" stroke-linecap="round"/>
+
+  <line x1="450" y1="150" x2="470" y2="145" stroke="black" stroke-width="2" stroke-linecap="round"/>
+  <line x1="445" y1="170" x2="475" y2="172" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="448" y1="190" x2="468" y2="195" stroke="black" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Ink splatter dots -->
+  <circle cx="60" cy="130" r="3" fill="black"/>
+  <circle cx="45" cy="210" r="2" fill="black"/>
+  <circle cx="440" cy="130" r="2.5" fill="black"/>
+  <circle cx="465" cy="205" r="2" fill="black"/>
+  <circle cx="100" cy="460" r="2" fill="black"/>
+  <circle cx="400" cy="455" r="2.5" fill="black"/>
+</svg>

--- a/frontend/src/assets/logo/octopus-comic-v2.svg
+++ b/frontend/src/assets/logo/octopus-comic-v2.svg
@@ -1,0 +1,182 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" fill="none">
+  <!-- Version 2: Manga / Cross-hatch Style - Fine lines, detailed shading -->
+  <title>BOSSVIEW Octopus - Manga Cross-hatch Style</title>
+
+  <defs>
+    <!-- Cross-hatch pattern for shading -->
+    <pattern id="crosshatch" x="0" y="0" width="6" height="6" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="black" stroke-width="0.6"/>
+    </pattern>
+    <pattern id="crosshatch-dense" x="0" y="0" width="4" height="4" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="4" stroke="black" stroke-width="0.5"/>
+      <line x1="0" y1="0" x2="4" y2="0" stroke="black" stroke-width="0.5"/>
+    </pattern>
+    <pattern id="lines-light" x="0" y="0" width="5" height="5" patternUnits="userSpaceOnUse" patternTransform="rotate(30)">
+      <line x1="0" y1="0" x2="0" y2="5" stroke="black" stroke-width="0.4"/>
+    </pattern>
+    <clipPath id="head-clip2">
+      <path d="M250 75 C315 75 368 118 378 182 C388 248 355 288 322 305 C300 318 278 322 250 322 C222 322 200 318 178 305 C145 288 112 248 122 182 C132 118 185 75 250 75Z"/>
+    </clipPath>
+  </defs>
+
+  <!-- Head -->
+  <path d="M250 75 C315 75 368 118 378 182 C388 248 355 288 322 305 C300 318 278 322 250 322 C222 322 200 318 178 305 C145 288 112 248 122 182 C132 118 185 75 250 75Z"
+        fill="white" stroke="black" stroke-width="2.5"/>
+
+  <!-- Head shadow (right side) with cross-hatching -->
+  <path d="M310 95 C355 125 378 175 378 200 C378 248 355 288 322 305 C305 315 285 320 268 322 C290 300 320 260 325 200 C328 150 318 115 310 95Z"
+        fill="url(#crosshatch)" clip-path="url(#head-clip2)"/>
+
+  <!-- Head shadow (bottom) -->
+  <path d="M180 285 C190 295 210 310 250 322 C220 322 200 318 178 305 C160 294 150 280 150 275Z"
+        fill="url(#crosshatch-dense)" clip-path="url(#head-clip2)"/>
+
+  <!-- Fine texture lines on head -->
+  <path d="M195 105 C200 98 215 92 225 90" stroke="black" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+  <path d="M190 115 C193 110 200 107 205 106" stroke="black" stroke-width="0.6" fill="none" stroke-linecap="round"/>
+  <path d="M187 128 C189 124 194 121 197 120" stroke="black" stroke-width="0.5" fill="none" stroke-linecap="round"/>
+
+  <!-- Eye - manga style with detailed iris -->
+  <ellipse cx="262" cy="200" rx="42" ry="48" fill="white" stroke="black" stroke-width="2.5"/>
+
+  <!-- Upper eyelid shadow -->
+  <path d="M222 178 C235 168 260 162 295 172 L298 180 C270 168 240 170 225 182Z" fill="black" opacity="0.15"/>
+
+  <!-- Iris -->
+  <circle cx="267" cy="208" r="24" fill="white" stroke="black" stroke-width="2"/>
+
+  <!-- Iris detail - radial lines (manga style) -->
+  <g stroke="black" stroke-width="0.5" opacity="0.6">
+    <line x1="267" y1="186" x2="267" y2="198"/>
+    <line x1="253" y1="190" x2="260" y2="200"/>
+    <line x1="281" y1="190" x2="274" y2="200"/>
+    <line x1="248" y1="200" x2="258" y2="205"/>
+    <line x1="286" y1="200" x2="276" y2="205"/>
+    <line x1="250" y1="215" x2="259" y2="212"/>
+    <line x1="284" y1="215" x2="275" y2="212"/>
+    <line x1="255" y1="225" x2="262" y2="218"/>
+    <line x1="279" y1="225" x2="272" y2="218"/>
+    <line x1="267" y1="230" x2="267" y2="220"/>
+  </g>
+
+  <!-- Pupil -->
+  <circle cx="267" cy="206" r="12" fill="black"/>
+
+  <!-- Pupil highlights (manga sparkle) -->
+  <circle cx="276" cy="196" r="7" fill="white"/>
+  <circle cx="260" cy="215" r="4" fill="white"/>
+  <circle cx="272" cy="214" r="2" fill="white"/>
+
+  <!-- Second eye (partially visible) -->
+  <ellipse cx="192" cy="212" rx="24" ry="28" fill="white" stroke="black" stroke-width="2"/>
+  <circle cx="189" cy="215" r="14" fill="white" stroke="black" stroke-width="1.5"/>
+  <!-- Iris lines -->
+  <g stroke="black" stroke-width="0.4" opacity="0.5">
+    <line x1="189" y1="203" x2="189" y2="210"/>
+    <line x1="180" y1="208" x2="185" y2="212"/>
+    <line x1="198" y1="208" x2="193" y2="212"/>
+    <line x1="181" y1="220" x2="186" y2="217"/>
+    <line x1="197" y1="220" x2="192" y2="217"/>
+  </g>
+  <circle cx="189" cy="214" r="7" fill="black"/>
+  <circle cx="194" cy="209" r="4" fill="white"/>
+  <circle cx="185" cy="219" r="2" fill="white"/>
+
+  <!-- Brow expression line -->
+  <path d="M212 168 C228 156 265 150 305 162" stroke="black" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M210 164 C215 160 220 158 225 157" stroke="black" stroke-width="1" fill="none" stroke-linecap="round"/>
+
+  <!-- Tentacle 1 - flowing left -->
+  <path d="M195 305 C170 345 125 395 100 435 C88 458 95 475 112 468 C130 460 128 440 122 418 C115 390 140 355 168 330"
+        fill="white" stroke="black" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Tentacle shading -->
+  <path d="M180 325 C170 345 150 380 135 405 C128 418 125 432 128 440"
+        stroke="black" stroke-width="0.5" fill="none" stroke-dasharray="1,3"/>
+  <!-- Suckers (detailed manga style) -->
+  <ellipse cx="170" cy="332" rx="5" ry="4" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="170" cy="332" rx="2.5" ry="2" fill="none" stroke="black" stroke-width="0.5"/>
+  <ellipse cx="152" cy="360" rx="5.5" ry="4.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="152" cy="360" rx="2.8" ry="2.2" fill="none" stroke="black" stroke-width="0.5"/>
+  <ellipse cx="135" cy="390" rx="5" ry="4" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="135" cy="390" rx="2.5" ry="2" fill="none" stroke="black" stroke-width="0.5"/>
+  <ellipse cx="118" cy="418" rx="4.5" ry="3.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="108" cy="445" rx="4" ry="3" fill="none" stroke="black" stroke-width="1.5"/>
+
+  <!-- Tentacle 2 - flowing right -->
+  <path d="M305 305 C335 345 382 380 420 388 C448 393 465 378 455 360 C445 342 425 345 405 355 C380 368 352 348 328 325"
+        fill="white" stroke="black" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M325 325 C345 348 370 368 390 372"
+        stroke="black" stroke-width="0.5" fill="none" stroke-dasharray="1,3"/>
+  <ellipse cx="330" cy="335" rx="5" ry="4" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="330" cy="335" rx="2.5" ry="2" fill="none" stroke="black" stroke-width="0.5"/>
+  <ellipse cx="355" cy="358" rx="5.5" ry="4.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="355" cy="358" rx="2.8" ry="2.2" fill="none" stroke="black" stroke-width="0.5"/>
+  <ellipse cx="383" cy="372" rx="5" ry="4" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="383" cy="372" rx="2.5" ry="2" fill="none" stroke="black" stroke-width="0.5"/>
+  <ellipse cx="408" cy="375" rx="4.5" ry="3.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="435" cy="370" rx="4" ry="3" fill="none" stroke="black" stroke-width="1.5"/>
+
+  <!-- Tentacle 3 - upper left curl -->
+  <path d="M155 280 C120 260 78 252 52 275 C35 290 40 312 58 314 C76 316 85 300 88 280 C92 260 115 255 142 268"
+        fill="white" stroke="black" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="125" cy="265" rx="4" ry="3.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="100" cy="260" rx="4" ry="3.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="78" cy="268" rx="3.5" ry="3" fill="none" stroke="black" stroke-width="1.2"/>
+  <ellipse cx="62" cy="285" rx="3" ry="2.5" fill="none" stroke="black" stroke-width="1.2"/>
+
+  <!-- Tentacle 4 - upper right curl -->
+  <path d="M345 280 C380 258 422 248 448 268 C465 282 462 305 445 308 C428 311 418 295 415 275 C410 255 388 250 358 265"
+        fill="white" stroke="black" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="375" cy="260" rx="4" ry="3.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="400" cy="254" rx="4" ry="3.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="425" cy="262" rx="3.5" ry="3" fill="none" stroke="black" stroke-width="1.2"/>
+  <ellipse cx="442" cy="280" rx="3" ry="2.5" fill="none" stroke="black" stroke-width="1.2"/>
+
+  <!-- Tentacle 5 - center left down -->
+  <path d="M218 318 C195 365 168 425 162 465 C159 482 170 490 182 483 C194 476 192 458 186 435 C178 402 198 368 218 340"
+        fill="white" stroke="black" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="205" cy="348" rx="5" ry="4" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="190" cy="382" rx="5" ry="4" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="178" cy="415" rx="4.5" ry="3.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="175" cy="448" rx="4" ry="3" fill="none" stroke="black" stroke-width="1.2"/>
+
+  <!-- Tentacle 6 - center right down -->
+  <path d="M282 318 C305 365 335 425 342 462 C345 480 335 490 322 484 C309 478 312 458 318 435 C328 402 308 368 288 340"
+        fill="white" stroke="black" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="298" cy="348" rx="5" ry="4" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="315" cy="385" rx="5" ry="4" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="328" cy="418" rx="4.5" ry="3.5" fill="none" stroke="black" stroke-width="1.5"/>
+  <ellipse cx="335" cy="450" rx="4" ry="3" fill="none" stroke="black" stroke-width="1.2"/>
+
+  <!-- Tentacle 7 - far left -->
+  <path d="M168 298 C135 325 92 368 70 408 C58 432 68 450 85 444 C102 438 98 418 92 398 C84 372 105 342 135 318"
+        fill="white" stroke="black" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="120" cy="335" rx="3.5" ry="3" fill="none" stroke="black" stroke-width="1.2"/>
+  <ellipse cx="100" cy="365" rx="3.5" ry="3" fill="none" stroke="black" stroke-width="1.2"/>
+  <ellipse cx="82" cy="395" rx="3" ry="2.5" fill="none" stroke="black" stroke-width="1"/>
+
+  <!-- Tentacle 8 - far right -->
+  <path d="M332 298 C365 325 408 365 430 402 C442 425 433 445 416 440 C399 435 402 415 408 395 C416 368 398 340 368 318"
+        fill="white" stroke="black" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="380" cy="332" rx="3.5" ry="3" fill="none" stroke="black" stroke-width="1.2"/>
+  <ellipse cx="402" cy="362" rx="3.5" ry="3" fill="none" stroke="black" stroke-width="1.2"/>
+  <ellipse cx="420" cy="392" rx="3" ry="2.5" fill="none" stroke="black" stroke-width="1"/>
+
+  <!-- Manga motion lines -->
+  <g stroke="black" stroke-width="0.8" stroke-linecap="round" opacity="0.5">
+    <line x1="42" y1="140" x2="18" y2="135"/>
+    <line x1="40" y1="152" x2="12" y2="152"/>
+    <line x1="42" y1="164" x2="18" y2="169"/>
+    <line x1="458" y1="140" x2="482" y2="135"/>
+    <line x1="460" y1="152" x2="488" y2="152"/>
+    <line x1="458" y1="164" x2="482" y2="169"/>
+  </g>
+
+  <!-- Small ink drops (manga effect) -->
+  <circle cx="55" cy="125" r="1.5" fill="black"/>
+  <circle cx="48" cy="180" r="1" fill="black"/>
+  <circle cx="445" cy="125" r="1.5" fill="black"/>
+  <circle cx="465" cy="178" r="1" fill="black"/>
+  <circle cx="95" cy="470" r="1.5" fill="black"/>
+  <circle cx="405" cy="465" r="1.5" fill="black"/>
+</svg>

--- a/frontend/src/assets/logo/octopus-comic-v3.svg
+++ b/frontend/src/assets/logo/octopus-comic-v3.svg
@@ -1,0 +1,166 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" fill="none">
+  <!-- Version 3: Minimalist Woodcut / Stencil Style - High contrast, bold shapes -->
+  <title>BOSSVIEW Octopus - Woodcut Stencil Style</title>
+
+  <!-- Head - solid black with white details carved out -->
+  <path d="M250 72 C320 72 375 120 385 188 C395 258 358 298 325 315 C302 328 278 332 250 332 C222 332 198 328 175 315 C142 298 105 258 115 188 C125 120 180 72 250 72Z"
+        fill="black" stroke="none"/>
+
+  <!-- White carved-out areas on head (woodcut effect) -->
+  <!-- Main highlight -->
+  <path d="M200 100 C215 88 240 82 260 85 C280 88 295 98 305 115 C290 100 265 90 240 90 C220 90 205 95 200 100Z"
+        fill="white"/>
+
+  <!-- Secondary highlight -->
+  <path d="M175 130 C180 120 190 112 200 110 C192 118 185 128 182 140Z"
+        fill="white"/>
+
+  <!-- Eye socket (white cutout) -->
+  <ellipse cx="265" cy="205" rx="44" ry="50" fill="white"/>
+
+  <!-- Iris ring -->
+  <circle cx="270" cy="210" r="26" fill="black"/>
+
+  <!-- Pupil highlight carved out -->
+  <circle cx="280" cy="198" r="9" fill="white"/>
+  <circle cx="264" cy="220" r="5" fill="white"/>
+
+  <!-- Second eye (white cutout, partially hidden) -->
+  <ellipse cx="188" cy="215" rx="26" ry="30" fill="white"/>
+  <circle cx="185" cy="218" r="15" fill="black"/>
+  <circle cx="191" cy="210" r="6" fill="white"/>
+  <circle cx="181" cy="224" r="3" fill="white"/>
+
+  <!-- Brow ridge (white line carved) -->
+  <path d="M210 170 C230 158 268 152 308 165" stroke="white" stroke-width="4" fill="none" stroke-linecap="round"/>
+
+  <!-- Under-eye texture (woodcut lines) -->
+  <path d="M230 260 C240 255 260 253 280 258" stroke="white" stroke-width="1.5" fill="none"/>
+  <path d="M235 268 C245 264 260 262 275 266" stroke="white" stroke-width="1" fill="none"/>
+
+  <!-- Head texture lines (woodcut grain) -->
+  <g stroke="white" stroke-width="0.8" fill="none" opacity="0.6">
+    <path d="M160 200 C165 195 172 192 180 190"/>
+    <path d="M155 215 C160 212 168 210 175 210"/>
+    <path d="M152 230 C158 228 165 227 172 228"/>
+    <path d="M320 160 C328 165 335 172 340 180"/>
+    <path d="M330 175 C336 180 342 188 345 196"/>
+    <path d="M335 195 C340 200 345 208 348 218"/>
+  </g>
+
+  <!-- Tentacle 1 - front left (solid black) -->
+  <path d="M195 315 C168 358 120 408 98 448 C85 472 94 490 115 482 C136 474 132 450 125 425 C116 395 145 355 175 328"
+        fill="black" stroke="none"/>
+  <!-- White carved lines for dimension -->
+  <path d="M185 330 C172 350 148 385 135 412" stroke="white" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M178 338 C168 355 150 382 140 405" stroke="white" stroke-width="1" fill="none"/>
+  <!-- Suckers (white carved circles) -->
+  <circle cx="168" cy="340" r="5.5" fill="white"/>
+  <circle cx="168" cy="340" r="2.5" fill="black"/>
+  <circle cx="148" cy="372" r="6" fill="white"/>
+  <circle cx="148" cy="372" r="2.8" fill="black"/>
+  <circle cx="130" cy="402" r="5.5" fill="white"/>
+  <circle cx="130" cy="402" r="2.5" fill="black"/>
+  <circle cx="118" cy="432" r="5" fill="white"/>
+  <circle cx="118" cy="432" r="2.2" fill="black"/>
+
+  <!-- Tentacle 2 - front right -->
+  <path d="M305 315 C338 355 388 388 428 395 C455 400 472 382 462 362 C452 342 430 346 408 358 C382 372 352 350 325 325"
+        fill="black" stroke="none"/>
+  <path d="M322 330 C345 355 375 375 400 380" stroke="white" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M328 338 C348 358 372 372 395 375" stroke="white" stroke-width="1" fill="none"/>
+  <circle cx="338" cy="342" r="5.5" fill="white"/>
+  <circle cx="338" cy="342" r="2.5" fill="black"/>
+  <circle cx="362" cy="365" r="6" fill="white"/>
+  <circle cx="362" cy="365" r="2.8" fill="black"/>
+  <circle cx="390" cy="378" r="5.5" fill="white"/>
+  <circle cx="390" cy="378" r="2.5" fill="black"/>
+  <circle cx="418" cy="378" r="5" fill="white"/>
+  <circle cx="418" cy="378" r="2.2" fill="black"/>
+
+  <!-- Tentacle 3 - upper left -->
+  <path d="M152 282 C118 262 72 255 45 280 C28 298 34 320 54 322 C74 324 84 305 88 282 C93 258 118 253 148 268"
+        fill="black" stroke="none"/>
+  <path d="M135 272 C112 262 85 262 70 275" stroke="white" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <circle cx="118" cy="268" r="4.5" fill="white"/>
+  <circle cx="118" cy="268" r="2" fill="black"/>
+  <circle cx="95" cy="264" r="4.5" fill="white"/>
+  <circle cx="95" cy="264" r="2" fill="black"/>
+  <circle cx="72" cy="274" r="4" fill="white"/>
+  <circle cx="72" cy="274" r="1.8" fill="black"/>
+
+  <!-- Tentacle 4 - upper right -->
+  <path d="M348 282 C382 260 428 250 455 272 C472 288 468 312 448 316 C428 320 418 300 415 278 C410 255 385 248 355 265"
+        fill="black" stroke="none"/>
+  <path d="M365 268 C390 258 418 258 435 270" stroke="white" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <circle cx="385" cy="262" r="4.5" fill="white"/>
+  <circle cx="385" cy="262" r="2" fill="black"/>
+  <circle cx="408" cy="258" r="4.5" fill="white"/>
+  <circle cx="408" cy="258" r="2" fill="black"/>
+  <circle cx="432" cy="268" r="4" fill="white"/>
+  <circle cx="432" cy="268" r="1.8" fill="black"/>
+
+  <!-- Tentacle 5 - center left down -->
+  <path d="M215 325 C192 372 162 438 158 475 C156 492 168 498 180 490 C192 482 190 462 182 438 C172 405 195 368 218 342"
+        fill="black" stroke="none"/>
+  <path d="M208 348 C195 375 178 418 175 452" stroke="white" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <circle cx="200" cy="358" r="5.5" fill="white"/>
+  <circle cx="200" cy="358" r="2.5" fill="black"/>
+  <circle cx="185" cy="392" r="5.5" fill="white"/>
+  <circle cx="185" cy="392" r="2.5" fill="black"/>
+  <circle cx="175" cy="425" r="5" fill="white"/>
+  <circle cx="175" cy="425" r="2.2" fill="black"/>
+  <circle cx="172" cy="458" r="4.5" fill="white"/>
+  <circle cx="172" cy="458" r="2" fill="black"/>
+
+  <!-- Tentacle 6 - center right down -->
+  <path d="M285 325 C308 372 342 438 348 472 C350 490 338 498 326 492 C314 486 318 462 324 438 C334 405 312 368 290 342"
+        fill="black" stroke="none"/>
+  <path d="M295 348 C310 378 330 422 338 458" stroke="white" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <circle cx="302" cy="358" r="5.5" fill="white"/>
+  <circle cx="302" cy="358" r="2.5" fill="black"/>
+  <circle cx="320" cy="395" r="5.5" fill="white"/>
+  <circle cx="320" cy="395" r="2.5" fill="black"/>
+  <circle cx="332" cy="428" r="5" fill="white"/>
+  <circle cx="332" cy="428" r="2.2" fill="black"/>
+  <circle cx="340" cy="460" r="4.5" fill="white"/>
+  <circle cx="340" cy="460" r="2" fill="black"/>
+
+  <!-- Tentacle 7 - far left -->
+  <path d="M165 300 C130 330 85 375 65 418 C52 445 65 462 82 455 C99 448 95 425 88 405 C78 378 102 345 135 318"
+        fill="black" stroke="none"/>
+  <path d="M148 318 C125 340 95 380 80 415" stroke="white" stroke-width="1.5" fill="none"/>
+  <circle cx="130" cy="338" r="4" fill="white"/>
+  <circle cx="130" cy="338" r="1.8" fill="black"/>
+  <circle cx="105" cy="370" r="4" fill="white"/>
+  <circle cx="105" cy="370" r="1.8" fill="black"/>
+  <circle cx="82" cy="402" r="3.5" fill="white"/>
+  <circle cx="82" cy="402" r="1.5" fill="black"/>
+
+  <!-- Tentacle 8 - far right -->
+  <path d="M335 300 C370 328 418 372 438 412 C452 438 440 458 422 452 C405 446 408 425 415 402 C424 375 402 342 370 318"
+        fill="black" stroke="none"/>
+  <path d="M355 318 C378 340 410 378 428 415" stroke="white" stroke-width="1.5" fill="none"/>
+  <circle cx="375" cy="335" r="4" fill="white"/>
+  <circle cx="375" cy="335" r="1.8" fill="black"/>
+  <circle cx="400" cy="368" r="4" fill="white"/>
+  <circle cx="400" cy="368" r="1.8" fill="black"/>
+  <circle cx="422" cy="400" r="3.5" fill="white"/>
+  <circle cx="422" cy="400" r="1.5" fill="black"/>
+
+  <!-- Ink splatter (woodcut/stencil effect) -->
+  <circle cx="42" cy="145" r="4" fill="black"/>
+  <circle cx="35" cy="155" r="2" fill="black"/>
+  <circle cx="48" cy="160" r="1.5" fill="black"/>
+  <circle cx="458" cy="142" r="3.5" fill="black"/>
+  <circle cx="465" cy="155" r="2" fill="black"/>
+  <circle cx="452" cy="158" r="1.5" fill="black"/>
+
+  <circle cx="40" cy="440" r="3" fill="black"/>
+  <circle cx="460" cy="435" r="2.5" fill="black"/>
+
+  <!-- Drip marks -->
+  <path d="M105 490 L105 498" stroke="black" stroke-width="2" stroke-linecap="round"/>
+  <path d="M400 488 L400 496" stroke="black" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="250" cy="498" r="2" fill="black"/>
+</svg>


### PR DESCRIPTION
## Beschreibung der Änderung

Drei neue SVG-Varianten des BOSSVIEW-Octopus-Logos wurden hinzugefügt, um verschiedene visuelle Stile für unterschiedliche Anwendungsfälle bereitzustellen:

1. **octopus-comic-v1.svg** - Bold Comic Style mit schweren Umrissen und Halftone-Schattierung
2. **octopus-comic-v2.svg** - Manga/Cross-Hatch Style mit feinen Linien und detaillierter Schraffur
3. **octopus-comic-v3.svg** - Minimalist Woodcut/Stencil Style mit Hochkontrast und kühnen Formen

Alle drei Varianten zeigen den gleichen Octopus-Charakter mit 8 Tentakeln, detaillierten Augen und Saugnäpfen, aber mit unterschiedlichen künstlerischen Techniken und Liniengewichten für verschiedene Design-Kontexte.

## Art der Änderung

- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Security
- [ ] Dokumentation

## Zugehörige Issues

Closes #

## Checkliste

- [ ] Tests geschrieben bzw. aktualisiert
- [ ] Audit-Trail berücksichtigt (CRUD-Operationen werden geloggt)
- [ ] Security-Review nötig? Falls ja, Ioannis als Reviewer hinzufügen
- [ ] CLAUDE.md aktualisiert (falls Projektstruktur oder Konventionen betroffen)
- [x] Keine Secrets im Code oder in Commits
- [ ] Docker-Services starten fehlerfrei (`docker compose up`)

**Anmerkungen:** Dies sind reine Asset-Dateien (SVG-Logos). Keine Tests oder Audit-Trail erforderlich. Die Dateien können direkt in der UI verwendet werden.

https://claude.ai/code/session_01DGhLm13M3wMcdNkBE26MDD